### PR TITLE
add selected byte information

### DIFF
--- a/src/binocle.rs
+++ b/src/binocle.rs
@@ -12,7 +12,7 @@ use crate::view::View;
 
 pub struct Binocle {
     pub settings: Settings,
-    buffer: Buffer,
+    pub buffer: Buffer,
 }
 
 impl Binocle {

--- a/src/gui.rs
+++ b/src/gui.rs
@@ -298,6 +298,36 @@ impl Gui {
             ui.checkbox(&mut settings.hex_view_visible, "hex view");
             ui.separator();
 
+            ui.add(egui::Label::new("Data information").heading());
+            let data_u128 = u128::from_le_bytes(settings.selected_data);
+            let data_u8 = data_u128 as u8;
+            let data_u16 = data_u128 as u16;
+            let data_u32 = data_u128 as u32;
+            let data_u64 = data_u128 as u64;
+            let mut to_label = |x: String| {
+                ui.add(egui::Label::new(x).monospace().wrap(false));
+            };
+            to_label(format!("byte: {}", settings.selected_byte));
+            to_label(format!("u8: {data_u8}"));
+            to_label(format!("i8: {}", data_u8 as i8));
+            to_label(format!("u16le: {data_u16}"));
+            to_label(format!("u16be: {}", data_u16.to_be()));
+            to_label(format!("i16le: {}", data_u16 as i16));
+            to_label(format!("i16be: {}", data_u16.to_be() as i16));
+            to_label(format!("u32le: {data_u32}"));
+            to_label(format!("u32be: {}", data_u32.to_be()));
+            to_label(format!("i32le: {}", data_u32 as i32));
+            to_label(format!("i32be: {}", data_u32.to_be() as i32));
+            to_label(format!("u64le: {data_u64}"));
+            to_label(format!("u64be: {}", data_u64.to_be()));
+            to_label(format!("i64le: {}", data_u64 as i64));
+            to_label(format!("i64be: {}", data_u64.to_be() as i64));
+            to_label(format!("f32le: {:e}", f32::from_bits(data_u32)));
+            to_label(format!("f32be: {:e}", f32::from_bits(data_u32.to_be())));
+            to_label(format!("f64le: {:e}", f64::from_bits(data_u64)));
+            to_label(format!("f64be: {:e}", f64::from_bits(data_u64.to_be())));
+
+            ui.separator();
             ui.add(egui::Label::new("Information").heading());
             let file_size = settings
                 .buffer_length

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -63,6 +63,9 @@ pub struct Settings {
 
     pub gui_wants_keyboard: bool,
     pub gui_wants_mouse: bool,
+
+    pub selected_byte: usize,
+    pub selected_data: [u8; 16],
 }
 
 impl Settings {
@@ -103,6 +106,8 @@ impl Default for Settings {
             hex_ascii: "".into(),
             gui_wants_keyboard: false,
             gui_wants_mouse: false,
+            selected_byte: 0,
+            selected_data: [0; 16],
         }
     }
 }


### PR DESCRIPTION
This add a section that display the current byte selected information into multiple formats:
![screen](https://github.com/sharkdp/binocle/assets/14872154/4f4c2336-f7dc-4d29-9469-a173690e5646)

TODO list:
- [x] Include byte information.
- [x] Update byte information based selected byte on main screen.
- [ ] Update byte information based selected byte on the Hex View.
- [ ] Draw a indicator to what byte is selected